### PR TITLE
perf: add lock to client

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,5 +16,5 @@ testacc:
 build-local: PROVIDER_VERSION ?= 0.0.1
 build-local:
 	go build -o terraform-provider-edge_v$(PROVIDER_VERSION)
-	mkdir -p ~/.terraform.d/plugins/local/edu/cairvine/$(PROVIDER_VERSION)/darwin_amd64
-	mv terraform-provider-edge_v$(PROVIDER_VERSION)  ~/.terraform.d/plugins/local/edu/cairvine/$(PROVIDER_VERSION)/darwin_amd64
+	mkdir -p ~/.terraform.d/plugins/local/edu/edge/$(PROVIDER_VERSION)/darwin_amd64
+	mv terraform-provider-edge_v$(PROVIDER_VERSION)  ~/.terraform.d/plugins/local/edu/edge/$(PROVIDER_VERSION)/darwin_amd64

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     edge = {
-      source = "ca-irvine/edge"
-      version = "0.0.1"
+      source  = "ca-irvine/edge"
+      version = "0.1.0"
     }
   }
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -106,7 +106,7 @@ func (v *config) GetValue(ctx context.Context, id string) (*model.Value, error) 
 		return nil, err
 	}
 
-	b, err := v.do(ctx, req)
+	b, err := v.do(ctx, req, false)
 
 	value := new(model.Value)
 	if err = json.Unmarshal(b, value); err != nil {
@@ -133,7 +133,7 @@ func (v *config) CreateValue(ctx context.Context, value *model.Value) error {
 		return err
 	}
 
-	_, err = v.do(ctx, req)
+	_, err = v.do(ctx, req, true)
 
 	return err
 }
@@ -161,7 +161,7 @@ func (v *config) UpdateValue(ctx context.Context, value *model.Value) error {
 		return err
 	}
 
-	_, err = v.do(ctx, req)
+	_, err = v.do(ctx, req, true)
 
 	return err
 }
@@ -184,12 +184,16 @@ func (v *config) DeleteValue(ctx context.Context, id string) error {
 		return err
 	}
 
-	_, err = v.do(ctx, req)
+	_, err = v.do(ctx, req, true)
 
 	return err
 }
 
-func (v *config) do(ctx context.Context, req *http.Request) ([]byte, error) {
+func (v *config) do(ctx context.Context, req *http.Request, useMutex bool) ([]byte, error) {
+	if useMutex {
+		v.m.Lock()
+		defer v.m.Unlock()
+	}
 	req.Header.Set(headerKeyID, v.keyID)
 	req.Header.Set(headerKey, v.key)
 	req.Header.Set(headerUA, v.ua)


### PR DESCRIPTION
### 概要
clientにmutexを導入しました。
primaryフラグの導入により問題になっていたデータ不整合は解消されておりましたが、provider側にロックを入れることで処理時間が短縮されました。

ロック導入前
```bash
edge_value.demo_string: Creating...
edge_value.demo_json: Creating...
edge_value.demo_bool: Creating...
edge_value.demo_json: Creation complete after 1s [id=demo-json-value]
edge_value.demo_string: Creation complete after 2s [id=demo-string-value]
edge_value.demo_bool: Creation complete after 5s [id=demo-bool-value]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```


ロック導入後
```bash
edge_value.demo_string: Creating...
edge_value.demo_json: Creating...
edge_value.demo_bool: Creating...
edge_value.demo_bool: Creation complete after 0s [id=demo-bool-value]
edge_value.demo_json: Creation complete after 0s [id=demo-json-value]
edge_value.demo_string: Creation complete after 1s [id=demo-string-value]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```
