### PR TITLE
refactor(model): renamed exp to expr

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     edge = {
       source  = "ca-irvine/edge"
-      version = "0.1.0"
+      version = "0.1.2"
     }
   }
 }
@@ -44,13 +44,13 @@ resource "edge_value" "demo_bool" {
   targeting {
     variant = "on"
     spec    = "cel"
-    exp     = "env == 'dev'"
+    expr    = "env == 'dev'"
   }
 
   targeting {
     variant = "on"
     spec    = "cel"
-    exp     = "userId == 'XXX'"
+    expr    = "userId == 'XXX'"
   }
 }
 
@@ -73,13 +73,13 @@ resource "edge_value" "demo_string" {
   targeting {
     variant = "string02"
     spec    = "cel"
-    exp     = "env == 'dev'"
+    expr    = "env == 'dev'"
   }
 
   targeting {
     variant = "string02"
     spec    = "cel"
-    exp     = "userId == 'XXX'"
+    expr    = "userId == 'XXX'"
   }
 }
 
@@ -106,12 +106,12 @@ resource "edge_value" "demo_json" {
   targeting {
     variant = "json02"
     spec    = "cel"
-    exp     = "env == 'dev'"
+    expr    = "env == 'dev'"
   }
 
   targeting {
     variant = "json02"
     spec    = "cel"
-    exp     = "userId == 'XXX'"
+    expr    = "userId == 'XXX'"
   }
 }

--- a/internal/model/value.go
+++ b/internal/model/value.go
@@ -38,7 +38,7 @@ type ValueTargeting struct {
 type ValueTargetingRule struct {
 	Variant string                 `json:"variant"`
 	Spec    ValueTargetingRuleSpec `json:"spec"`
-	Exp     string                 `json:"exp"`
+	Expr    string                 `json:"expr"`
 }
 
 type ValueTargetingRuleSpec string

--- a/internal/provider/resource_edge_value.go
+++ b/internal/provider/resource_edge_value.go
@@ -203,7 +203,7 @@ func buildValueTargeting(_ context.Context, d *schema.ResourceData) (*model.Valu
 		rules = append(rules, model.ValueTargetingRule{
 			Variant: variant,
 			Spec:    specInt,
-			Exp:     exp,
+			Expr:    exp,
 		})
 	}
 

--- a/internal/provider/resource_edge_value_test.go
+++ b/internal/provider/resource_edge_value_test.go
@@ -52,10 +52,10 @@ func TestAccResourceEdgeValue_BooleanValue(t *testing.T) {
 					resource.TestCheckResourceAttr("edge_value.test-bool-value", "targeting.#", "2"),
 					resource.TestCheckResourceAttr("edge_value.test-bool-value", "targeting.0.variant", "on"),
 					resource.TestCheckResourceAttr("edge_value.test-bool-value", "targeting.0.spec", "cel"),
-					resource.TestCheckResourceAttr("edge_value.test-bool-value", "targeting.0.exp", "env == 'dev'"),
+					resource.TestCheckResourceAttr("edge_value.test-bool-value", "targeting.0.expr", "env == 'dev'"),
 					resource.TestCheckResourceAttr("edge_value.test-bool-value", "targeting.1.variant", "on"),
 					resource.TestCheckResourceAttr("edge_value.test-bool-value", "targeting.1.spec", "cel"),
-					resource.TestCheckResourceAttr("edge_value.test-bool-value", "targeting.1.exp", "userId == 'XXX'"),
+					resource.TestCheckResourceAttr("edge_value.test-bool-value", "targeting.1.expr", "userId == 'XXX'"),
 				),
 			},
 		},
@@ -175,13 +175,13 @@ resource "edge_value" "test-bool-value" {
   targeting {
     variant = "on"
     spec = "cel"
-    exp = "env == 'dev'"
+    expr = "env == 'dev'"
   }
 
   targeting {
     variant = "on"
     spec = "cel"
-    exp = "userId == 'XXX'"
+    expr = "userId == 'XXX'"
   }
 }`
 }


### PR DESCRIPTION
認知負荷を下げるため、評価式をexpからexprにリネームします。