### PR TITLE
fix(test): fixed value test variable to use jsonencode

### DIFF
--- a/internal/provider/resource_edge_value.go
+++ b/internal/provider/resource_edge_value.go
@@ -138,8 +138,8 @@ func resourceEdgeValue() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"variables": {
-							Description: "Variables for test cases.",
-							Type:        schema.TypeMap,
+							Description: "Variables json string for test cases.",
+							Type:        schema.TypeString,
 							Required:    true,
 						},
 						"expected": {
@@ -272,8 +272,16 @@ func buildEvaluationTests(d *schema.ResourceData) ([]*model.EvaluationTest, erro
 	tests := make([]*model.EvaluationTest, 0, len(list))
 	for i := range list {
 		m := list[i].(map[string]any)
+
+		s := m["variables"].(string)
+		vars := map[string]any{}
+		err := json.Unmarshal([]byte(s), &vars)
+		if err != nil {
+			return nil, err
+		}
+
 		tests = append(tests, &model.EvaluationTest{
-			Variables: m["variables"].(map[string]any),
+			Variables: vars,
 			Expected:  m["expected"].(string),
 		})
 	}

--- a/internal/provider/resource_edge_value_test.go
+++ b/internal/provider/resource_edge_value_test.go
@@ -57,8 +57,7 @@ func TestAccResourceEdgeValue_BooleanValue(t *testing.T) {
 					resource.TestCheckResourceAttr("edge_value.test-bool-value", "targeting.1.spec", "cel"),
 					resource.TestCheckResourceAttr("edge_value.test-bool-value", "targeting.1.expr", "userId == 'XXX'"),
 					resource.TestCheckResourceAttr("edge_value.test-bool-value", "test.#", "1"),
-					resource.TestCheckResourceAttr("edge_value.test-bool-value", "test.0.variables.env", "test"),
-					resource.TestCheckResourceAttr("edge_value.test-bool-value", "test.0.variables.userId", "XXX"),
+					resource.TestCheckResourceAttr("edge_value.test-bool-value", "test.0.variables", "{\"count\":1,\"env\":\"test\"}"),
 					resource.TestCheckResourceAttr("edge_value.test-bool-value", "test.0.expected", "on"),
 				),
 			},
@@ -235,10 +234,10 @@ resource "edge_value" "test-bool-value" {
   }
 	
   test {
-	variables = {
+	variables = jsonencode({
 	  env = "test"
-	  userId = "XXX"
-	}
+	  count = 1
+	})
 	expected = "on"
   }
 }`


### PR DESCRIPTION
テストディレクティブに記述したint型の値が、内部で`map[string]any`にキャストすることによりstringとして扱われてしまっていたため、intのまま扱えるように修正します。
- jsonencodeした値をterraformで記述するようにスキーマを変更
- 内部で`map[string]any`にUnmarshalする処理を追加