### PR TITLE
fix(validation): include empty json

### DIFF
--- a/internal/provider/resource_value.go
+++ b/internal/provider/resource_value.go
@@ -159,7 +159,7 @@ func (v *ValueResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 							Required: true,
 							Validators: []validator.String{
 								stringvalidator.RegexMatches(
-									regexp.MustCompile(`^{.+}$`),
+									regexp.MustCompile(`^{.*}$`),
 									"Must be map object, not array",
 								),
 							},


### PR DESCRIPTION
json valueのvalidationで、`{}`が含まれない正規表現になっていたので修正。